### PR TITLE
Make MPFVideoCapture use frame skipper by default.

### DIFF
--- a/detection/api/include/MPFVideoCapture.h
+++ b/detection/api/include/MPFVideoCapture.h
@@ -54,7 +54,7 @@ namespace MPF { namespace COMPONENT {
          * @throws std::invalid_argument videoJob contains invalid property
          */
         explicit MPFVideoCapture(const MPFVideoJob &videoJob, bool enableFrameTransformers=true,
-                                 bool enableFrameSkipper=false);
+                                 bool enableFrameSkipper=true);
 
         /**
          * Initializes a new MPFVideoCapture instance, using the frame


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf-cpp-component-sdk/17)
<!-- Reviewable:end -->
