### PR TITLE
Allow the user to specify a region of interest for cropping as a perc…

### DIFF
--- a/detection/api/src/frame_transformers/FrameTransformerFactory.cpp
+++ b/detection/api/src/frame_transformers/FrameTransformerFactory.cpp
@@ -24,7 +24,7 @@
  * limitations under the License.                                             *
  ******************************************************************************/
 
-#include <iostream>
+#include <sstream>
 #include <string>
 #include <utility>
 
@@ -39,209 +39,246 @@
 
 
 using std::string;
+using DetectionComponentUtils::GetProperty;
 
 namespace MPF { namespace COMPONENT { namespace FrameTransformerFactory {
 
-    namespace {
+namespace {
 
-        cv::Rect GetSearchRegion(const Properties &jobProperties, const cv::Size &frameSize) {
+int GetPercentOfDimension(const std::string &percentString, const int dimension) {
 
-            int regionTopLeftXPos = DetectionComponentUtils::GetProperty(
-                    jobProperties, "SEARCH_REGION_TOP_LEFT_X_DETECTION", -1);
-            if (regionTopLeftXPos < 0) {
-                regionTopLeftXPos = 0;
-            }
-
-            int regionTopLeftYPos = DetectionComponentUtils::GetProperty(
-                    jobProperties, "SEARCH_REGION_TOP_LEFT_Y_DETECTION", -1);
-            if (regionTopLeftYPos < 0) {
-                regionTopLeftYPos = 0;
-            }
-
-            cv::Point topLeft(regionTopLeftXPos, regionTopLeftYPos);
-
-            int regionBottomRightXPos = DetectionComponentUtils::GetProperty(
-                    jobProperties, "SEARCH_REGION_BOTTOM_RIGHT_X_DETECTION", -1);
-            if (regionBottomRightXPos <= 0) {
-                regionBottomRightXPos = frameSize.width;
-            }
-
-            int regionBottomRightYPos = DetectionComponentUtils::GetProperty(
-                    jobProperties, "SEARCH_REGION_BOTTOM_RIGHT_Y_DETECTION", -1);
-            if (regionBottomRightYPos <= 0) {
-                regionBottomRightYPos = frameSize.height;
-            }
-            cv::Point bottomRight(regionBottomRightXPos, regionBottomRightYPos);
-
-            return cv::Rect(topLeft, bottomRight);
-        }
+    float percentNum;
+    std::istringstream(percentString) >> percentNum;
+    if (percentNum < 0.0) {
+        return 0;
+    }
+    else if (percentNum > 100.0) {
+        return dimension;
+    }
+    return (percentNum*dimension)/100.0;
+}
 
 
-        cv::Rect toRect(const MPFImageLocation &imageLocation) {
-            return {imageLocation.x_left_upper, imageLocation.y_left_upper, imageLocation.width, imageLocation.height};
-        }
+cv::Rect GetSearchRegion(const Properties &jobProperties, const cv::Size &frameSize) {
+
+    int position;
+    string topLeftX = GetProperty(jobProperties, "SEARCH_REGION_TOP_LEFT_X_DETECTION", string("-1"));
+    int regionTopLeftXPos;
+    size_t idx = topLeftX.find("%");
+    if (idx != string::npos) {
+        regionTopLeftXPos = GetPercentOfDimension(topLeftX.substr(0, idx), frameSize.width);
+    }
+    else {
+        std::istringstream(topLeftX) >> position;
+        regionTopLeftXPos = (position < 0) ? 0 : position;
+    }
+
+    string topLeftY = GetProperty(jobProperties, "SEARCH_REGION_TOP_LEFT_Y_DETECTION", string("-1"));
+    int regionTopLeftYPos;
+    idx = topLeftY.find("%");
+    if (idx != string::npos) {
+        regionTopLeftYPos = GetPercentOfDimension(topLeftY.substr(0, idx), frameSize.height);
+    }
+    else {
+        std::istringstream(topLeftY) >> position;
+        regionTopLeftYPos = (position < 0) ? 0 : position;
+    }
+
+    cv::Point topLeft(regionTopLeftXPos, regionTopLeftYPos);
+
+    string bottomRightX = GetProperty(jobProperties, "SEARCH_REGION_BOTTOM_RIGHT_X_DETECTION", string("-1"));
+    int regionBottomRightXPos;
+    idx = bottomRightX.find("%");
+    if (idx != string::npos) {
+        regionBottomRightXPos = GetPercentOfDimension(bottomRightX.substr(0, idx), frameSize.width);
+    }
+    else {
+        std::istringstream(bottomRightX) >> position;
+        regionBottomRightXPos = (position <= 0) ? frameSize.width : position;
+    }
+
+    string bottomRightY = GetProperty(jobProperties, "SEARCH_REGION_BOTTOM_RIGHT_Y_DETECTION", string("-1"));
+    int regionBottomRightYPos;
+    idx = bottomRightY.find("%");
+    if (idx != string::npos) {
+        regionBottomRightYPos = GetPercentOfDimension(bottomRightY.substr(0, idx), frameSize.height);
+    }
+    else {
+        std::istringstream(bottomRightY) >> position;
+        regionBottomRightYPos = (position <= 0) ? frameSize.height : position;
+    }
+
+    cv::Point bottomRight(regionBottomRightXPos, regionBottomRightYPos);
+
+    return cv::Rect(topLeft, bottomRight);
+}
 
 
-        /**
-         *
-         * @param feedForwardTrackLocations
-         * @return The minimum area rectangle that contains all detections listed in feedForwardTrackLocations
-         */
-        cv::Rect GetSupersetRegion(const std::map<int, MPFImageLocation> &feedForwardTrackLocations) {
-            if (feedForwardTrackLocations.empty()) {
-                throw std::length_error(
-                        "FEED_FORWARD_TYPE: SUPERSET_REGION is enabled, but feed forward track was empty.");
-            }
-
-            auto it = feedForwardTrackLocations.begin();
-            cv::Rect region = toRect(it->second);
-            it++;
-
-            for (; it != feedForwardTrackLocations.end(); it++) {
-                region |= toRect(it->second);
-            }
-            return region;
-        }
+cv::Rect toRect(const MPFImageLocation &imageLocation) {
+    return {imageLocation.x_left_upper, imageLocation.y_left_upper, imageLocation.width, imageLocation.height};
+}
 
 
-        bool FeedForwardSupersetRegionIsEnabled(const Properties &jobProperties) {
-            return "SUPERSET_REGION" ==
-                    DetectionComponentUtils::GetProperty(jobProperties, "FEED_FORWARD_TYPE", string());
-        }
+/**
+ *
+ * @param feedForwardTrackLocations
+ * @return The minimum area rectangle that contains all detections listed in feedForwardTrackLocations
+ */
+cv::Rect GetSupersetRegion(const std::map<int, MPFImageLocation> &feedForwardTrackLocations) {
+    if (feedForwardTrackLocations.empty()) {
+        throw std::length_error(
+            "FEED_FORWARD_TYPE: SUPERSET_REGION is enabled, but feed forward track was empty.");
+    }
+
+    auto it = feedForwardTrackLocations.begin();
+    cv::Rect region = toRect(it->second);
+    it++;
+
+    for (; it != feedForwardTrackLocations.end(); it++) {
+        region |= toRect(it->second);
+    }
+    return region;
+}
 
 
-        bool FeedForwardExactRegionIsEnabled(const Properties &jobProperties) {
-            return "REGION" == DetectionComponentUtils::GetProperty(jobProperties, "FEED_FORWARD_TYPE", string());
-        }
+bool FeedForwardSupersetRegionIsEnabled(const Properties &jobProperties) {
+    return "SUPERSET_REGION" ==
+            DetectionComponentUtils::GetProperty(jobProperties, "FEED_FORWARD_TYPE", string());
+}
 
 
-        bool SearchRegionCroppingIsEnabled(const Properties &jobProperties) {
-            return DetectionComponentUtils::GetProperty(jobProperties, "SEARCH_REGION_ENABLE_DETECTION", false);
-        }
+bool FeedForwardExactRegionIsEnabled(const Properties &jobProperties) {
+    return "REGION" == DetectionComponentUtils::GetProperty(jobProperties, "FEED_FORWARD_TYPE", string());
+}
 
 
-        void AddFlipperIfNeeded(const Properties &jobProperties, const Properties &mediaProperties,
-                                IFrameTransformer::Ptr &currentTransformer) {
-            bool shouldFlip;
-            if (DetectionComponentUtils::GetProperty(jobProperties, "AUTO_FLIP", false)) {
-                shouldFlip = DetectionComponentUtils::GetProperty(mediaProperties, "HORIZONTAL_FLIP", false);
-            }
-            else {
-                shouldFlip = DetectionComponentUtils::GetProperty(jobProperties, "HORIZONTAL_FLIP", false);
-            }
-
-            if (shouldFlip) {
-                currentTransformer = IFrameTransformer::Ptr(new FrameFlipper(std::move(currentTransformer)));
-            }
-        }
+bool SearchRegionCroppingIsEnabled(const Properties &jobProperties) {
+    return DetectionComponentUtils::GetProperty(jobProperties, "SEARCH_REGION_ENABLE_DETECTION", false);
+}
 
 
-        void AddRotatorIfNeeded(const Properties &jobProperties, const Properties &mediaProperties,
-                                IFrameTransformer::Ptr &currentTransformer) {
-            string rotationKey = "ROTATION";
-            int rotation = 0;
-            if (DetectionComponentUtils::GetProperty(jobProperties, "AUTO_ROTATE", false)) {
-                rotation = DetectionComponentUtils::GetProperty(mediaProperties, rotationKey, 0);
-            }
-            else {
-                rotation = DetectionComponentUtils::GetProperty(jobProperties, rotationKey, 0);
-            }
+void AddFlipperIfNeeded(const Properties &jobProperties, const Properties &mediaProperties,
+                        IFrameTransformer::Ptr &currentTransformer) {
+    bool shouldFlip;
+    if (DetectionComponentUtils::GetProperty(jobProperties, "AUTO_FLIP", false)) {
+        shouldFlip = DetectionComponentUtils::GetProperty(mediaProperties, "HORIZONTAL_FLIP", false);
+    }
+    else {
+        shouldFlip = DetectionComponentUtils::GetProperty(jobProperties, "HORIZONTAL_FLIP", false);
+    }
 
-            if (rotation != 0 && rotation != 90 && rotation != 180 && rotation != 270) {
-                throw MPFInvalidPropertyException(rotationKey,
-                                                  "Rotation degrees must be 0, 90, 180, or 270.",
-                                                  MPF_INVALID_ROTATION);
-            }
-
-            if (rotation != 0) {
-                currentTransformer = IFrameTransformer::Ptr(new FrameRotator(std::move(currentTransformer), rotation));
-            }
-        }
+    if (shouldFlip) {
+        currentTransformer = IFrameTransformer::Ptr(new FrameFlipper(std::move(currentTransformer)));
+    }
+}
 
 
-        void AddCropperIfNeeded(const cv::Rect &regionOfInterest, const cv::Size &inputVideoSize,
-                                IFrameTransformer::Ptr &currentTransformer) {
+void AddRotatorIfNeeded(const Properties &jobProperties, const Properties &mediaProperties,
+                        IFrameTransformer::Ptr &currentTransformer) {
+    string rotationKey = "ROTATION";
+    int rotation = 0;
+    if (DetectionComponentUtils::GetProperty(jobProperties, "AUTO_ROTATE", false)) {
+        rotation = DetectionComponentUtils::GetProperty(mediaProperties, rotationKey, 0);
+    }
+    else {
+        rotation = DetectionComponentUtils::GetProperty(jobProperties, rotationKey, 0);
+    }
 
-            bool regionOfInterestIsEntireFrame = cv::Rect({0, 0}, inputVideoSize) == regionOfInterest;
-            if (!regionOfInterestIsEntireFrame) {
-                currentTransformer = IFrameTransformer::Ptr(
-                        new SearchRegionFrameCropper(std::move(currentTransformer), regionOfInterest));
-            }
-        }
+    if (rotation != 0 && rotation != 90 && rotation != 180 && rotation != 270) {
+        throw MPFInvalidPropertyException(rotationKey,
+                                          "Rotation degrees must be 0, 90, 180, or 270.",
+                                          MPF_INVALID_ROTATION);
+    }
 
-
-        void AddCropperIfNeeded(const MPFJob &job, const cv::Size &inputVideoSize,
-                                const std::map<int, MPFImageLocation> &trackLocations,
-                                IFrameTransformer::Ptr &currentTransformer) {
-
-            bool exactRegionCroppingEnabled = FeedForwardExactRegionIsEnabled(job.job_properties);
-            bool supersetRegionCroppingEnabled = FeedForwardSupersetRegionIsEnabled(job.job_properties);
-            bool searchRegionCroppingEnabled = SearchRegionCroppingIsEnabled(job.job_properties);
-
-            if (!exactRegionCroppingEnabled && !supersetRegionCroppingEnabled && !searchRegionCroppingEnabled) {
-                return;
-            }
-
-            if ((exactRegionCroppingEnabled || supersetRegionCroppingEnabled) && searchRegionCroppingEnabled) {
-                std::cerr << "Both feed forward cropping and search region cropping properties were provided. "
-                          << "Only feed forward cropping will occur." << std::endl;
-            }
+    if (rotation != 0) {
+        currentTransformer = IFrameTransformer::Ptr(new FrameRotator(std::move(currentTransformer), rotation));
+    }
+}
 
 
-            if (exactRegionCroppingEnabled) {
-                currentTransformer = IFrameTransformer::Ptr(
-                        new FeedForwardFrameCropper(std::move(currentTransformer), trackLocations));
-                return;
-            }
+void AddCropperIfNeeded(const cv::Rect &regionOfInterest, const cv::Size &inputVideoSize,
+                        IFrameTransformer::Ptr &currentTransformer) {
+
+    bool regionOfInterestIsEntireFrame = cv::Rect({0, 0}, inputVideoSize) == regionOfInterest;
+    if (!regionOfInterestIsEntireFrame) {
+        currentTransformer = IFrameTransformer::Ptr(
+            new SearchRegionFrameCropper(std::move(currentTransformer), regionOfInterest));
+    }
+}
 
 
-            cv::Rect regionOfInterest;
-            if (supersetRegionCroppingEnabled) {
-                regionOfInterest = GetSupersetRegion(trackLocations);
-            }
-            else {
-                regionOfInterest = GetSearchRegion(job.job_properties, inputVideoSize);
-            }
-            AddCropperIfNeeded(regionOfInterest, inputVideoSize, currentTransformer);
-        }
+void AddCropperIfNeeded(const MPFJob &job, const cv::Size &inputVideoSize,
+                        const std::map<int, MPFImageLocation> &trackLocations,
+                        IFrameTransformer::Ptr &currentTransformer) {
 
+    bool exactRegionCroppingEnabled = FeedForwardExactRegionIsEnabled(job.job_properties);
+    bool supersetRegionCroppingEnabled = FeedForwardSupersetRegionIsEnabled(job.job_properties);
+    bool searchRegionCroppingEnabled = SearchRegionCroppingIsEnabled(job.job_properties);
 
-        IFrameTransformer::Ptr GetTransformer(const MPFJob &job, const cv::Size &inputVideoSize,
-                                              const std::map<int, MPFImageLocation> &trackLocations) {
+    if (!exactRegionCroppingEnabled && !supersetRegionCroppingEnabled && !searchRegionCroppingEnabled) {
+        return;
+    }
 
-            IFrameTransformer::Ptr transformer(new NoOpFrameTransformer(inputVideoSize));
-
-            AddRotatorIfNeeded(job.job_properties, job.media_properties, transformer);
-            AddFlipperIfNeeded(job.job_properties, job.media_properties, transformer);
-            AddCropperIfNeeded(job, inputVideoSize, trackLocations, transformer);
-
-            return transformer;
-        }
+    if ((exactRegionCroppingEnabled || supersetRegionCroppingEnabled) && searchRegionCroppingEnabled) {
+        std::cerr << "Both feed forward cropping and search region cropping properties were provided. "
+                  << "Only feed forward cropping will occur." << std::endl;
     }
 
 
-
-    IFrameTransformer::Ptr GetTransformer(const MPFVideoJob &job, const cv::Size &inputVideoSize) {
-        return GetTransformer(job, inputVideoSize, job.feed_forward_track.frame_locations);
+    if (exactRegionCroppingEnabled) {
+        currentTransformer = IFrameTransformer::Ptr(
+            new FeedForwardFrameCropper(std::move(currentTransformer), trackLocations));
+        return;
     }
 
 
-    IFrameTransformer::Ptr GetTransformer(const MPFImageJob &job, const cv::Size &inputVideoSize) {
-        return GetTransformer(job, inputVideoSize, { { 0, job.feed_forward_location } });
+    cv::Rect regionOfInterest;
+    if (supersetRegionCroppingEnabled) {
+        regionOfInterest = GetSupersetRegion(trackLocations);
     }
-
-
-    IFrameTransformer::Ptr GetTransformer(const MPFStreamingVideoJob &job, const cv::Size &inputVideoSize) {
-
-        IFrameTransformer::Ptr transformer(new NoOpFrameTransformer(inputVideoSize));
-
-        AddRotatorIfNeeded(job.job_properties, job.media_properties, transformer);
-        AddFlipperIfNeeded(job.job_properties, job.media_properties, transformer);
-
-        if (SearchRegionCroppingIsEnabled(job.job_properties)) {
-            AddCropperIfNeeded(GetSearchRegion(job.job_properties, inputVideoSize),
-                               inputVideoSize, transformer);
-        }
-        return transformer;
+    else {
+        regionOfInterest = GetSearchRegion(job.job_properties, inputVideoSize);
     }
+    AddCropperIfNeeded(regionOfInterest, inputVideoSize, currentTransformer);
+}
+
+
+IFrameTransformer::Ptr GetTransformer(const MPFJob &job, const cv::Size &inputVideoSize,
+                                      const std::map<int, MPFImageLocation> &trackLocations) {
+
+    IFrameTransformer::Ptr transformer(new NoOpFrameTransformer(inputVideoSize));
+
+    AddRotatorIfNeeded(job.job_properties, job.media_properties, transformer);
+    AddFlipperIfNeeded(job.job_properties, job.media_properties, transformer);
+    AddCropperIfNeeded(job, inputVideoSize, trackLocations, transformer);
+
+    return transformer;
+}
+}
+
+
+
+IFrameTransformer::Ptr GetTransformer(const MPFVideoJob &job, const cv::Size &inputVideoSize) {
+    return GetTransformer(job, inputVideoSize, job.feed_forward_track.frame_locations);
+}
+
+
+IFrameTransformer::Ptr GetTransformer(const MPFImageJob &job, const cv::Size &inputVideoSize) {
+    return GetTransformer(job, inputVideoSize, { { 0, job.feed_forward_location } });
+}
+
+
+IFrameTransformer::Ptr GetTransformer(const MPFStreamingVideoJob &job, const cv::Size &inputVideoSize) {
+
+    IFrameTransformer::Ptr transformer(new NoOpFrameTransformer(inputVideoSize));
+
+    AddRotatorIfNeeded(job.job_properties, job.media_properties, transformer);
+    AddFlipperIfNeeded(job.job_properties, job.media_properties, transformer);
+
+    if (SearchRegionCroppingIsEnabled(job.job_properties)) {
+        AddCropperIfNeeded(GetSearchRegion(job.job_properties, inputVideoSize),
+                           inputVideoSize, transformer);
+    }
+    return transformer;
+}
 }}}

--- a/detection/examples/ImageTransformerComponent/plugin-files/descriptor/descriptor.json
+++ b/detection/examples/ImageTransformerComponent/plugin-files/descriptor/descriptor.json
@@ -32,26 +32,26 @@
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_X_DETECTION",
-          "description": "X coordinate for top left corner of cropped frame. If negative, 0 will be used.",
-          "type": "INT",
+          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_Y_DETECTION",
-          "description": "Y coordinate for top left corner of cropped frame. If negative, 0 will be used.",
-          "type": "INT",
+          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_X_DETECTION",
-          "description": "X coordinate for bottom right corner of cropped frame. If negative, bottom right X of input media will be used.",
-          "type": "INT",
+          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right X position will be set to the width of the frame.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_Y_DETECTION",
-          "description": "Y coordinate for bottom right corner of cropped frame. If negative, bottom right Y of input media. will be used.",
-          "type": "INT",
+          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right Y position will be set to the height of the frame.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {

--- a/detection/examples/VideoCaptureComponent/plugin-files/descriptor/descriptor.json
+++ b/detection/examples/VideoCaptureComponent/plugin-files/descriptor/descriptor.json
@@ -32,26 +32,26 @@
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_X_DETECTION",
-          "description": "X coordinate for top left corner of cropped frame. If negative, 0 will be used.",
-          "type": "INT",
+          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_Y_DETECTION",
-          "description": "Y coordinate for top left corner of cropped frame. If negative, 0 will be used.",
-          "type": "INT",
+          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_X_DETECTION",
-          "description": "X coordinate for bottom right corner of cropped frame. If negative, bottom right X of input media will be used.",
-          "type": "INT",
+          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right X position will be set to the width of the frame.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_Y_DETECTION",
-          "description": "Y coordinate for bottom right corner of cropped frame. If negative, bottom right Y of input media. will be used.",
-          "type": "INT",
+          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right Y position will be set to the height of the frame.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {


### PR DESCRIPTION
…entage of the frame dimensions (#75)

* The FrameTransformerFactory was modified to compute the FrameCropper search region based on coordinates defined explicitly as pixel locations, or defined as a percentage of the frame dimensions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf-cpp-component-sdk/84)
<!-- Reviewable:end -->
