### PR TITLE
Add support for ROTATION_THRESHOLD and ROTATION_FILL_COLOR

### DIFF
--- a/detection/api/include/frame_transformers/AffineFrameTransformer.h
+++ b/detection/api/include/frame_transformers/AffineFrameTransformer.h
@@ -47,6 +47,7 @@ namespace MPF { namespace COMPONENT {
         AffineTransformation(
                 const std::vector<MPFRotatedRect> &preTransformRegions,
                 double frameRotationDegrees, bool flip,
+                const cv::Scalar &fillColor,
                 const SearchRegion &postTransformSearchRegion = {});
 
         void Apply(cv::Mat &frame) const;
@@ -62,6 +63,8 @@ namespace MPF { namespace COMPONENT {
 
         cv::Size2d regionSize_;
 
+        cv::Scalar fillColor_;
+
         // OpenCV does the mapping in the reverse order (from destination to the source) to avoid sampling artifacts.
         cv::Matx23d reverseTransformationMatrix_;
     };
@@ -72,16 +75,17 @@ namespace MPF { namespace COMPONENT {
 
     public:
         // Search region frame cropping on rotated frame constructor.
-        AffineFrameTransformer(double rotation, bool flip, const SearchRegion &searchRegion,
+        AffineFrameTransformer(double rotation, bool flip, const cv::Scalar &fillColor,
+                               const SearchRegion &searchRegion,
                                IFrameTransformer::Ptr innerTransform);
 
         // Rotate full frame constructor.
-        AffineFrameTransformer(double rotation, bool flip,
+        AffineFrameTransformer(double rotation, bool flip, const cv::Scalar &fillColor,
                                IFrameTransformer::Ptr innerTransform);
 
         // Feed forward superset region constructor
         AffineFrameTransformer(const std::vector<MPFRotatedRect> &regions,
-                               double frameRotation, bool frameFlip,
+                               double frameRotation, bool frameFlip, const cv::Scalar &fillColor,
                                IFrameTransformer::Ptr innerTransform);
 
         cv::Size GetFrameSize(int frameIndex) override;
@@ -103,6 +107,7 @@ namespace MPF { namespace COMPONENT {
     public:
         // Feed forward exact region constructor
         FeedForwardExactRegionAffineTransformer(const std::vector<MPFRotatedRect> &regions,
+                                                const cv::Scalar &fillColor,
                                                 IFrameTransformer::Ptr innerTransform);
 
         cv::Size GetFrameSize(int frameIndex) override;
@@ -119,7 +124,7 @@ namespace MPF { namespace COMPONENT {
         const AffineTransformation& GetTransform(int frameIndex) const;
 
         static std::vector<AffineTransformation> CreateTransformations(
-                const std::vector<MPFRotatedRect> &regions);
+                const std::vector<MPFRotatedRect> &regions, const cv::Scalar &fillColor);
 
     };
 }}

--- a/detection/api/src/detectionComponentUtils.cpp
+++ b/detection/api/src/detectionComponentUtils.cpp
@@ -124,7 +124,16 @@ namespace DetectionComponentUtils {
 
 
     bool RotationAnglesEqual(double a1, double a2, double epsilon) {
-        return std::abs(NormalizeAngle(a1) - NormalizeAngle(a2)) < epsilon;
+        a1 = NormalizeAngle(a1);
+        a2 = NormalizeAngle(a2);
+        if (std::abs(a1 - a2) < epsilon) {
+            return true;
+        }
+        else {
+            double a1_dist = std::min(a1, std::abs(360 - a1));
+            double a2_dist = std::min(a2, std::abs(360 - a2));
+            return (a1_dist + a2_dist) < epsilon;
+        }
     }
 }
  

--- a/detection/api/src/frame_transformers/FrameTransformerFactory.cpp
+++ b/detection/api/src/frame_transformers/FrameTransformerFactory.cpp
@@ -95,13 +95,14 @@ namespace {
 
 
     bool FeedForwardSupersetRegionIsEnabled(const Properties &jobProperties) {
-        return "SUPERSET_REGION" ==
-                DetectionComponentUtils::GetProperty(jobProperties, "FEED_FORWARD_TYPE", "");
+        return boost::iequals("SUPERSET_REGION",
+                              GetProperty(jobProperties, "FEED_FORWARD_TYPE", ""));
     }
 
 
     bool FeedForwardExactRegionIsEnabled(const Properties &jobProperties) {
-        return "REGION" == DetectionComponentUtils::GetProperty(jobProperties, "FEED_FORWARD_TYPE", "");
+        return boost::iequals("REGION",
+                              GetProperty(jobProperties, "FEED_FORWARD_TYPE", ""));
     }
 
 
@@ -111,8 +112,7 @@ namespace {
 
 
     cv::Scalar GetFillColor(const Properties &props) {
-        auto fillColorName = DetectionComponentUtils::GetProperty(
-                props, "ROTATION_FILL_COLOR", "BLACK");
+        auto fillColorName = GetProperty(props, "ROTATION_FILL_COLOR", "BLACK");
         if (boost::iequals("BLACK", fillColorName)) {
             return {0, 0, 0};
         }

--- a/detection/api/src/frame_transformers/FrameTransformerFactory.cpp
+++ b/detection/api/src/frame_transformers/FrameTransformerFactory.cpp
@@ -32,6 +32,8 @@
 #include <utility>
 #include <vector>
 
+#include <boost/algorithm/string/predicate.hpp>
+
 #include <opencv2/core.hpp>
 
 #include "detectionComponentUtils.h"
@@ -111,10 +113,10 @@ namespace {
     cv::Scalar GetFillColor(const Properties &props) {
         auto fillColorName = DetectionComponentUtils::GetProperty(
                 props, "ROTATION_FILL_COLOR", "BLACK");
-        if (fillColorName == "BLACK") {
+        if (boost::iequals("BLACK", fillColorName)) {
             return {0, 0, 0};
         }
-        else if (fillColorName == "WHITE") {
+        else if (boost::iequals("WHITE", fillColorName)) {
             return {255, 255, 255};
         }
         else {


### PR DESCRIPTION
Resolves https://github.com/openmpf/openmpf/issues/1194
Resolves https://github.com/openmpf/openmpf/issues/1196

Associated PRs:
- https://github.com/openmpf/openmpf/pull/1195
- https://github.com/openmpf/openmpf-components/pull/203
- https://github.com/openmpf/openmpf-cpp-component-sdk/pull/93
- https://github.com/openmpf/openmpf-python-component-sdk/pull/33

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf-cpp-component-sdk/93)
<!-- Reviewable:end -->
